### PR TITLE
Update search.py

### DIFF
--- a/app/services/events/search.py
+++ b/app/services/events/search.py
@@ -59,7 +59,7 @@ class HLTVEventsSearch(HLTVBase):
             flag_url = event.get("flagUrl")
             event_logo_url = event.get("eventLogo")
             event_type = event.get("eventType")
-            event_matches_url = f"https://www.hltv.org{event.get("eventMatchesLocation")}"
+            event_matches_url = f"https://www.hltv.org{event.get('eventMatchesLocation')}"
 
             results.append({
                 "id": str(id),


### PR DESCRIPTION
Fixed search.py docker run error



  File "/app/app/main.py", line 9, in <module>

    from app.api.api import api_router

  File "/app/app/api/api.py", line 4, in <module>

    from app.api.endpoints import events

  File "/app/app/api/endpoints/events.py", line 7, in <module>

    from app.services.events.search import HLTVEventsSearch

  File "/app/app/services/events/search.py", line 62

    event_matches_url = f"https://www.hltv.org{event.get("eventMatchesLocation")}"

SyntaxError: f-string: unmatched '('

Traceback (most recent call last):